### PR TITLE
Small improvements made to your amazing implementation of Rust's Result.

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,14 @@
+export class NoOkValueError extends Error {
+  constructor() {
+    super("Cannot unwrap a failed result");
+    this.name = "NoOkValueError";
+  }
+}
+
+export class NoFailValueError extends Error {
+  constructor() {
+    super("Cannot unwrapFail a successful result");
+    this.name = "NoFailValueError";
+  }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './result';
+export * from './errors';

--- a/test/result.spec.ts
+++ b/test/result.spec.ts
@@ -45,7 +45,7 @@ describe("Result", () => {
     it("should convert where each key is a result into a result with that unwrapped object, leaving plain keys as they are", () => {
       const objectWithResults = {
         name: Result.ok("NAME"),
-        surname: "SURNAME",
+        surname: Result.ok("SURNAME"),
         age: Result.ok(20),
       };
 
@@ -63,7 +63,7 @@ describe("Result", () => {
     it("should return the first error if one of the object keys has a failing result", () => {
       const objectWithResults = {
         name: Result.ok("NAME"),
-        surname: "SURNAME",
+        surname: Result.ok("SURNAME"),
         age: Result.fail(ERROR),
       };
 


### PR DESCRIPTION
chore: improved type safety on collect and collectObject methods;
fix: isResult method now behaves more reliably;
refactor: collect and collect object methods now only iterate once over
  results/object properties;
  